### PR TITLE
Test point

### DIFF
--- a/src/View/ImageFusion/ManualFusionLoader.py
+++ b/src/View/ImageFusion/ManualFusionLoader.py
@@ -188,7 +188,7 @@ class ManualFusionLoader(QtCore.QObject):
                 ds = pydicom.dcmread(transform_file)
 
                 # See explanation at top for more details on private tags
-                if hasattr(ds, "RegistrationSequence") or (0x7777, 0x0010) in ds:
+                if hasattr(ds, "RegistrationSequence") or (0x7777, 0x0020) in ds or (0x7777, 0x0021) in ds:
                     transform_data = self._extracted_from__load_with_vtk_62(ds, np, transform_file)
                 else:
                     raise ValueError("Selected transform.dcm is not a valid Spatial Registration Object.")

--- a/src/View/ImageFusion/TranslateRotateMenu.py
+++ b/src/View/ImageFusion/TranslateRotateMenu.py
@@ -869,7 +869,7 @@ class TranslateRotateMenu(QtWidgets.QWidget):
             if hasattr(ds, "RegistrationSequence"):
                 self._extracted_from_load_fusion_state_sro(ds, np, vtk_engine, filename)
             #fallback to private tags if above failed
-            elif (0x7777, 0x0010) in ds:
+            elif (0x7777, 0x0020) in ds or (0x7777, 0x0021) in ds:
                 self._extracted_from_load_fusion_state_sro(ds, np, vtk_engine, filename)
             else:
                 logging.error("No spatial registration found in DICOM file.\nPlease select a transform.dcm file "

--- a/src/View/ImageFusion/TranslateRotateMenu.py
+++ b/src/View/ImageFusion/TranslateRotateMenu.py
@@ -21,6 +21,26 @@ from pydicom import dcmread
 from pydicom.dataset import Dataset
 from pydicom.uid import generate_uid
 
+"""
+    For all private tags 0x7777, 0x0020 / 0x7777, 0x0021 / etc
+    these are private dicom tags for extra info used as fallback if the normal registration tag for loading the saved transform fails. 
+    (saving normal rego first means it can be used by other programs. Private tags can only be read by onko dicom).
+    they must use an odd group number i.e 0x7777 and an element number i.e 0x0010, can be saved as any odd number group 
+    and must be consistent in the program as it needs to know it to read private tags
+
+    This is saved and set in Translate rotation menu _create_spatial_registration_dicom
+    9/10/25 in line 650 & 651
+    
+    # Save user translation/rotation as private tags for round-trip
+        ds.add_new((0x7777, 0x0020), 'LT', ",".join([str(v) for v in translation]))
+        ds.add_new((0x7777, 0x0021), 'LT', ",".join([str(v) for v in rotation]))
+        
+    see links for more details
+        https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_7.8.html
+        https://pydicom.github.io/pydicom/stable/guides/user/private_data_elements.html
+
+"""
+
 
 def get_color_pair_from_text(text):
     """

--- a/test/ImageFusion/test_image_fusion_tab_builder.py
+++ b/test/ImageFusion/test_image_fusion_tab_builder.py
@@ -1,0 +1,135 @@
+# test/test_view_image_fusion_tab_builder.py
+
+import pytest
+from unittest.mock import MagicMock
+
+from src.View.ImageFusion.ImageFusionTabBuilder import ImageFusionTabBuilder
+
+class DummyMainWindow:
+    """
+    Dummy main window class for testing ImageFusionTabBuilder.
+
+    This mock class records calls to setup methods and simulates the attributes and methods
+    expected by the ImageFusionTabBuilder. It is used to verify that the builder interacts
+    with the main window as expected during tab construction.
+    """
+    def __init__(self):
+        self.structures_tab = MagicMock()
+        self.structures_tab.rois = {}
+        self.structures_tab.update_ui = MagicMock()
+        self.left_panel = MagicMock()
+        self.right_panel = MagicMock()
+        self.last_fusion_slice_orientation = None
+        self.last_fusion_slice_idx = None
+        self.images = {"vtk_engine": "dummy_engine"}
+        self.action_handler = MagicMock()
+        self.setup_calls = []
+
+    def _init_fusion_views(self, vtk_engine):
+        """Record initialization of fusion views."""
+        self.setup_calls.append(("init_fusion_views", vtk_engine))
+        self.image_fusion_single_view = MagicMock()
+        self.image_fusion_view_axial = MagicMock()
+        self.image_fusion_view_sagittal = MagicMock()
+        self.image_fusion_view_coronal = MagicMock()
+
+    def init_windowing_slider(self):
+        """Record windowing slider initialization."""
+        self.setup_calls.append("init_windowing_slider")
+
+    def init_roi_transfer_option_view(self):
+        """Record ROI transfer option view initialization."""
+        self.setup_calls.append("init_roi_transfer_option_view")
+
+    def init_fusion_slice_tracking(self):
+        """Record fusion slice tracking initialization."""
+        self.setup_calls.append("init_fusion_slice_tracking")
+
+    def apply_transform_if_present(self, vtk_engine):
+        """Record application of transform if present."""
+        self.setup_calls.append(("apply_transform_if_present", vtk_engine))
+
+    def connect_slider_callbacks(self):
+        """Record connection of slider callbacks."""
+        self.setup_calls.append("connect_slider_callbacks")
+
+    def set_slider_ranges(self):
+        """Record setting of slider ranges."""
+        self.setup_calls.append("set_slider_ranges")
+
+    def setup_static_overlays_if_no_vtk(self, vtk_engine):
+        """Record setup of static overlays if no VTK engine is present."""
+        self.setup_calls.append(("setup_static_overlays_if_no_vtk", vtk_engine))
+
+    def rescale_and_update_fusion_views(self):
+        """Record rescaling and updating of fusion views."""
+        self.setup_calls.append("rescale_and_update_fusion_views")
+
+    def setup_fusion_four_views_layout(self):
+        """Record setup of the four-views layout."""
+        self.setup_calls.append("setup_fusion_four_views_layout")
+
+    def finalize_fusion_tab(self):
+        """Record finalization of the fusion tab."""
+        self.setup_calls.append("finalize_fusion_tab")
+
+@pytest.fixture
+def dummy_main_window():
+    """
+    Pytest fixture to provide a fresh DummyMainWindow instance for each test.
+    """
+    return DummyMainWindow()
+
+@pytest.mark.parametrize(
+    "manual,expected_methods",
+    [
+        (
+            True,
+            [
+                "init_windowing_slider",
+                "init_roi_transfer_option_view",
+                "init_fusion_slice_tracking",
+                "connect_slider_callbacks",
+                "set_slider_ranges",
+                "rescale_and_update_fusion_views",
+                "setup_fusion_four_views_layout",
+                "finalize_fusion_tab",
+            ],
+        ),
+        (
+            False,
+            [
+                "init_windowing_slider",
+                "init_roi_transfer_option_view",
+                "init_fusion_slice_tracking",
+                "connect_slider_callbacks",
+                "set_slider_ranges",
+                "rescale_and_update_fusion_views",
+                "setup_fusion_four_views_layout",
+                "finalize_fusion_tab",
+            ],
+        ),
+    ],
+)
+def test_image_fusion_tab_builder(dummy_main_window, manual, expected_methods):
+    """
+    Test that ImageFusionTabBuilder correctly sets up the main window for both manual and auto fusion.
+
+    This test verifies that the builder creates the fusion options tab (for manual) and calls all
+    expected setup methods on the main window when building the fusion tab.
+    """
+    builder = ImageFusionTabBuilder(dummy_main_window, manual=manual)
+    builder.build()
+
+    # Check that the fusion options tab was created (should always exist for compatibility)
+    assert hasattr(dummy_main_window, "fusion_options_tab")
+
+    # Assert each expected method was called at least once, without using a loop in the test logic
+    assert any("init_windowing_slider" in str(call) for call in dummy_main_window.setup_calls)
+    assert any("init_roi_transfer_option_view" in str(call) for call in dummy_main_window.setup_calls)
+    assert any("init_fusion_slice_tracking" in str(call) for call in dummy_main_window.setup_calls)
+    assert any("connect_slider_callbacks" in str(call) for call in dummy_main_window.setup_calls)
+    assert any("set_slider_ranges" in str(call) for call in dummy_main_window.setup_calls)
+    assert any("rescale_and_update_fusion_views" in str(call) for call in dummy_main_window.setup_calls)
+    assert any("setup_fusion_four_views_layout" in str(call) for call in dummy_main_window.setup_calls)
+    assert any("finalize_fusion_tab" in str(call) for call in dummy_main_window.setup_calls)


### PR DESCRIPTION
looking for issue origin

## Summary by Sourcery

Support round-trip saving and loading of user translation and rotation via private DICOM tags, refine transform file detection, and enhance error handling and logging.

New Features:
- Add support for saving and reading private DICOM tags (0x7777, 0x0020 / 0x0021) for user translation and rotation fallback.

Bug Fixes:
- Correct private tag element checks to use 0x0020/0x0021 instead of 0x0010 when loading fusion state.

Enhancements:
- Filter out transform DICOM files from the image series before loading to separate transform handling.
- Wrap transform extraction in try/catch to emit error signals and improve resilience.
- Improve logging by replacing logging.error with logging.exception for image loading failures.
- Update TranslateRotateMenu to recognize the new private tags when loading fusion state.

Documentation:
- Add docstrings detailing private DICOM tag usage, constraints, and reference links.