### PR TITLE
Syncing branch

### DIFF
--- a/src/Model/NiftiToRtstructConverter.py
+++ b/src/Model/NiftiToRtstructConverter.py
@@ -231,7 +231,7 @@ def nifti_to_rtstruct_conversion(nifti_path: str, dicom_path: str, output_path: 
     try:
         for img_path in nifti_files_list:
             _process_nifti_file(str(img_path), dicom_img, rtstruct, segment_name_map)
-        rtstruct.save(rtss_path)
+        rtstruct.save(str(rtss_path))
         return True
     except Exception as e:
         logger.error(f"Conversion failed: {type(e).__name__}: {e}")

--- a/src/Model/VTKEngine.py
+++ b/src/Model/VTKEngine.py
@@ -140,7 +140,7 @@ def cleanup_old_dicom_temp_dirs(temp_root=None):
 
 # ------------------------------ VTK Processing Engine ------------------------------
 
-WINDOW_DEFAULT = 390
+WINDOW_DEFAULT = 400
 LEVEL_DEFAULT = 40
 
 class VTKEngine:

--- a/src/Model/Windowing.py
+++ b/src/Model/Windowing.py
@@ -19,26 +19,18 @@ def windowing_model(text, init):
     # Use custom window/level for manual fusion overlays (init[3])
     #TODO This is just a patch. Need to figure out why VTK doesnt work with default dicom windowing
     if init[3]:
-        # You can use a custom dictionary here, or load from MovingDictContainer
-        moving_dict_container = MovingDictContainer()
-        dict_windowing_moving = moving_dict_container.get("dict_windowing_moving")
-        if dict_windowing_moving and text in dict_windowing_moving:
-            windowing_limits = dict_windowing_moving[text]
-        else:
-            # Fallback to a hardcoded set or the fixed image's presets
-            custom_presets = {
-                "Normal": [390, 40],  # Soft tissue, covers -160 to 240 HU
-                "Lung": [1600, -600],  # Lung, covers -1400 to 200 HU
-                "Bone": [2000, 300],  # Bone, covers -700 to 1300 HU
-                "Brain": [80, 40],  # Brain, covers 0 to 80 HU
-                "Soft Tissue": [440, 40],  # Alias for Normal
-                "Head and Neck": [275, 40],  # Covers -147.5 to 227.5 HU
-            }
-            windowing_limits = custom_presets.get(text, [400, 40])
+        custom_presets = {
+            "Normal": [390, 40],  # Soft tissue, covers -160 to 240 HU
+            "Lung": [1600, -600],  # Lung, covers -1400 to 200 HU
+            "Bone": [2000, 300],  # Bone, covers -700 to 1300 HU
+            "Brain": [80, 40],  # Brain, covers 0 to 80 HU
+            "Soft Tissue": [440, 40],  # Alias for Normal
+            "Head and Neck": [275, 40],  # Covers -147.5 to 227.5 HU
+        }
+        windowing_limits = custom_presets.get(text, [400, 40])
     else:
         windowing_limits = patient_dict_container.get("dict_windowing")[text]
 
-    # Set window and level to the new values
     window = windowing_limits[0]
     level = windowing_limits[1]
 
@@ -110,12 +102,14 @@ def windowing_model_direct(window, level, init, fixed_image_array=None):
                 'windowing_slider' in globals()
                 and windowing_slider is not None
                 and hasattr(windowing_slider, "fusion_views")
-                and windowing_slider.fusion_views is not None
+                and windowing_slider.fusion_views
         ):
             for view in windowing_slider.fusion_views:
                 if hasattr(view, "vtk_engine") and view.vtk_engine is not None:
+
                     view.vtk_engine.set_window_level(float(window), float(level))
                 if hasattr(view, "update_color_overlay"):
+
                     view.update_color_overlay()
             # Also call the fusion window/level callback if present (ensures views update)
             if hasattr(windowing_slider, "fusion_window_level_callback") and callable(
@@ -146,7 +140,5 @@ def set_windowing_slider(slider, fusion_views=None):
     global windowing_slider
     windowing_slider = slider
 
-    if fusion_views is not None:
-        windowing_slider.fusion_views = fusion_views
-    elif hasattr(windowing_slider, "fusion_views"):
-        windowing_slider.fusion_views = None
+    windowing_slider.fusion_views = fusion_views if fusion_views is not None else []
+

--- a/src/Model/Windowing.py
+++ b/src/Model/Windowing.py
@@ -16,6 +16,7 @@ def windowing_model(text, init):
     """
     patient_dict_container = PatientDictContainer()
 
+
     # Use custom window/level for manual fusion overlays (init[3])
     #TODO This is just a patch. Need to figure out why VTK doesnt work with default dicom windowing
     if init[3]:

--- a/src/Model/Windowing.py
+++ b/src/Model/Windowing.py
@@ -20,11 +20,11 @@ def windowing_model(text, init):
     #TODO This is just a patch. Need to figure out why VTK doesnt work with default dicom windowing
     if init[3]:
         custom_presets = {
-            "Normal": [390, 40],  # Soft tissue, covers -160 to 240 HU
+            "Normal": [400, 40],  # Normal levels (typical soft tissue window)
             "Lung": [1600, -600],  # Lung, covers -1400 to 200 HU
             "Bone": [2000, 300],  # Bone, covers -700 to 1300 HU
             "Brain": [80, 40],  # Brain, covers 0 to 80 HU
-            "Soft Tissue": [440, 40],  # Alias for Normal
+            "Soft Tissue": [440, 40],  # Soft tissue, covers -180 to 260 HU (muscle, fat, organs)
             "Head and Neck": [275, 40],  # Covers -147.5 to 227.5 HU
         }
         windowing_limits = custom_presets.get(text, [400, 40])

--- a/src/View/mainpage/DVHTab.py
+++ b/src/View/mainpage/DVHTab.py
@@ -160,7 +160,7 @@ class DVHTab(QtWidgets.QWidget):
             ax.legend(loc='upper left', bbox_to_anchor=(-0.1, -0.15), ncol=4)
 
         plt.subplots_adjust(bottom=0.3)
-
+        plt.close()
         return fig
 
     def prompt_calc_dvh(self):

--- a/src/View/mainpage/DrawROIWindow/DrawROIInitialiser.py
+++ b/src/View/mainpage/DrawROIWindow/DrawROIInitialiser.py
@@ -286,10 +286,6 @@ class RoiInitialiser():
              self.current_roi.setText(self.canvas_labal.roi_name)
        
 
-    def close_roi_window(self):
-        """Closes the roi window"""
-        self._toolbar.close()
-
     def copy_roi(self):
         """
         Allows the ablity to copy ROIs onto different areas and handles the popups

--- a/src/View/mainpage/WindowingSlider.py
+++ b/src/View/mainpage/WindowingSlider.py
@@ -363,7 +363,7 @@ class WindowingSlider(QWidget):
 
         # Apply the window/level changes using the model
         with wait_cursor():
-            windowing_model_direct(level, window, send)
+            windowing_model_direct(window, level, send)
 
             # Update fusion overlays if present
             try:

--- a/test/test_model_batch_processes.py
+++ b/test/test_model_batch_processes.py
@@ -33,6 +33,7 @@ from src.Model.batchprocessing. \
 
 
 class TestObject:
+    __test__ = False
 
     def __init__(self):
         self.batch_dir = Path.cwd().joinpath('test', 'batchtestdata')

--- a/test/test_view_drawing.py
+++ b/test/test_view_drawing.py
@@ -126,7 +126,7 @@ def test_change_transparency_slider_value(qtbot, test_object, init_config):
     paint_bucket = True
 
     # First flood with alpha = 100
-    draw_roi_window.units_box.transparency_slider.setValue(100)
+    draw_roi_window._toolbar.update_transparency(100)
     color = draw_roi_window.pen.color()
     color.setAlpha(100)
     draw_roi_window.pen.setColor(color)
@@ -139,7 +139,7 @@ def test_change_transparency_slider_value(qtbot, test_object, init_config):
     ).toImage().pixelColor(*mid_point).alpha()
 
     # Second flood with alpha = 50
-    draw_roi_window.units_box.transparency_slider.setValue(50)
+    draw_roi_window._toolbar.update_transparency(50)
     color = draw_roi_window.pen.color()
     color.setAlpha(50)
     draw_roi_window.pen.setColor(color)

--- a/test/test_view_drawing.py
+++ b/test/test_view_drawing.py
@@ -157,7 +157,7 @@ def test_change_transparency_slider_value(qtbot, test_object, init_config):
     draw_roi_window.canvas_labal.erase_roi()
 
     # Closing the roi window
-    draw_roi_window.close_roi_window()
+    draw_roi_window.close_window()
 
 def test_manual_drawing(qtbot, test_object, init_config):
     """Test that manual drawing changes the canvas where previously empty."""
@@ -200,7 +200,7 @@ def test_manual_drawing(qtbot, test_object, init_config):
     draw_roi_window.canvas_labal.erase_roi()
 
     # Closing the roi window
-    draw_roi_window.close_roi_window()
+    draw_roi_window.close_window()
 
 
 def test_roi_windowing(qtbot, test_object):
@@ -233,4 +233,4 @@ def test_roi_windowing(qtbot, test_object):
     assert existing_level != new_level, "Level should be updated via handler"
 
     # Closing the roi window
-    draw_roi_window.close_roi_window()
+    draw_roi_window.close_window()

--- a/test/test_view_drawing.py
+++ b/test/test_view_drawing.py
@@ -68,11 +68,12 @@ class TestDrawingMock:
         self.main_window = MainWindow()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def test_object():
     """Function to initialise a Drawing window object."""
     test = TestDrawingMock()
-    return test
+    yield test
+    test.main_window.close()
 
 
 def test_draw_roi_window_displayed(qtbot, test_object):
@@ -125,7 +126,7 @@ def test_change_transparency_slider_value(qtbot, test_object, init_config):
     paint_bucket = True
 
     # First flood with alpha = 100
-    draw_roi_window._toolbar.update_transparency(100)
+    draw_roi_window.units_box.transparency_slider.setValue(100)
     color = draw_roi_window.pen.color()
     color.setAlpha(100)
     draw_roi_window.pen.setColor(color)
@@ -138,7 +139,7 @@ def test_change_transparency_slider_value(qtbot, test_object, init_config):
     ).toImage().pixelColor(*mid_point).alpha()
 
     # Second flood with alpha = 50
-    draw_roi_window._toolbar.update_transparency(50)
+    draw_roi_window.units_box.transparency_slider.setValue(50)
     color = draw_roi_window.pen.color()
     color.setAlpha(50)
     draw_roi_window.pen.setColor(color)
@@ -155,6 +156,8 @@ def test_change_transparency_slider_value(qtbot, test_object, init_config):
     # Clear canvas to ensure no conflicts with other tests
     draw_roi_window.canvas_labal.erase_roi()
 
+    # Closing the roi window
+    draw_roi_window.close_roi_window()
 
 def test_manual_drawing(qtbot, test_object, init_config):
     """Test that manual drawing changes the canvas where previously empty."""
@@ -196,6 +199,9 @@ def test_manual_drawing(qtbot, test_object, init_config):
     # Clear canvas to ensure no conflicts with other tests
     draw_roi_window.canvas_labal.erase_roi()
 
+    # Closing the roi window
+    draw_roi_window.close_roi_window()
+
 
 def test_roi_windowing(qtbot, test_object):
     """Tests that the windowing action items update the draw ROI windowing display."""
@@ -226,3 +232,5 @@ def test_roi_windowing(qtbot, test_object):
     assert existing_window != new_window, "Window should be updated via handler"
     assert existing_level != new_level, "Level should be updated via handler"
 
+    # Closing the roi window
+    draw_roi_window.close_roi_window()

--- a/test/test_view_dvh_tab.py
+++ b/test/test_view_dvh_tab.py
@@ -83,7 +83,8 @@ class TestDVHTab:
 def test_object():
     """Function to pass a shared TestStructureTab object to each test."""
     test = TestDVHTab()
-    return test
+    yield test
+    test.main_window.close()
 
 
 def wait_for_widget(layout, timeout=1000):

--- a/test/test_view_first_time_welcome_window.py
+++ b/test/test_view_first_time_welcome_window.py
@@ -7,7 +7,7 @@ from src.Controller.GUIController import FirstTimeWelcomeWindow
 from src.Model.Configuration import Configuration
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def init_first_time_window_config(request):
     configuration = Configuration('TestFirstTimeWelcomeWindow.db')
     db_file_path = Path(os.environ['USER_ONKODICOM_HIDDEN']).joinpath('TestFirstTimeWelcomeWindow.db')

--- a/test/test_view_first_time_welcome_window.py
+++ b/test/test_view_first_time_welcome_window.py
@@ -7,7 +7,7 @@ from src.Controller.GUIController import FirstTimeWelcomeWindow
 from src.Model.Configuration import Configuration
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def init_first_time_window_config(request):
     configuration = Configuration('TestFirstTimeWelcomeWindow.db')
     db_file_path = Path(os.environ['USER_ONKODICOM_HIDDEN']).joinpath('TestFirstTimeWelcomeWindow.db')

--- a/test/test_view_manipulate_roi.py
+++ b/test/test_view_manipulate_roi.py
@@ -83,7 +83,8 @@ class TestManipulateROI:
 def test_object():
     """Function to pass a shared TestManipulateROI object to each test."""
     test = TestManipulateROI()
-    return test
+    yield test
+    test.main_window.close()
 
 
 def test_input_form(test_object):

--- a/test/test_view_structures_tab.py
+++ b/test/test_view_structures_tab.py
@@ -85,7 +85,8 @@ class TestStructureTab:
 def test_object():
     """Function to pass a shared TestStructureTab object to each test."""
     test = TestStructureTab()
-    return test
+    yield test
+    test.main_window.close()
 
 
 def test_structure_tab_check_checkboxes(test_object):

--- a/test/test_view_structures_tab.py
+++ b/test/test_view_structures_tab.py
@@ -81,7 +81,7 @@ class TestStructureTab:
         self.curr_slice = self.dicom_view.patient_dict_container.get("dict_uid")[slider_id]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def test_object():
     """Function to pass a shared TestStructureTab object to each test."""
     test = TestStructureTab()


### PR DESCRIPTION
## Summary by Sourcery

Simplify windowing presets and slider behavior, correct default values and argument ordering, improve resource cleanup in plotting and conversion, and enhance test teardown and isolation

Bug Fixes:
- Fix parameter order in windowing_model_direct invocation to apply correct window/level values
- Close matplotlib figures in DVHTab.plot_dvh to prevent resource leaks
- Cast pathlib.Path to string when saving RTSTRUCT in NiftiToRtstructConverter
- Update default window constant in VTKEngine to match preset values
- Mark TestObject in batch process tests as non-test to avoid unintended test discovery

Enhancements:
- Simplify manual fusion windowing logic by using a fixed custom_presets dictionary
- Initialize fusion_views to an empty list in set_windowing_slider to ensure consistent behavior
- Remove unused close_roi_window method from ROI initialiser

Tests:
- Convert pytest fixtures to yield style with teardown to close main windows after tests
- Adjust fixture scopes and add explicit window closures in drawing tests to improve isolation